### PR TITLE
sanitize cpf numbers to avoid error on database creation process

### DIFF
--- a/src/Core/Domain/Employee/Entities/Employee.cs
+++ b/src/Core/Domain/Employee/Entities/Employee.cs
@@ -21,7 +21,7 @@ public class Employee : Person
         bool isActive,
         int id = 0)
     {
-        Cpf = cpf;
+        Cpf = new string(cpf.Where(char.IsDigit).ToArray());
         Name = name;
         Surname = surname;
         Email = email;


### PR DESCRIPTION
This pull request includes a small change to the `Employee` entity in `src/Core/Domain/Employee/Entities/Employee.cs`. The change ensures that the `Cpf` property is sanitized by retaining only numeric characters.