### PR TITLE
create cpf extension method to sanitize

### DIFF
--- a/src/Core/Domain/Base/Extensions/CpfValidationExtensions.cs
+++ b/src/Core/Domain/Base/Extensions/CpfValidationExtensions.cs
@@ -38,5 +38,10 @@
 
             return cpf.EndsWith(digit);
         }
+        
+        public static string SanitizeCpf(this string cpf)
+        {
+            return new string(cpf.Where(char.IsDigit).ToArray());
+        }
     }
 }

--- a/src/Core/Domain/Customer/Entities/Customer.cs
+++ b/src/Core/Domain/Customer/Entities/Customer.cs
@@ -18,7 +18,7 @@ public class Customer : Person
         bool isActive,
         int id = 0)
     {
-        Cpf = cpf;
+        Cpf = cpf.SanitizeCpf();
         Name = name;
         Surname = surname;
         Email = email;

--- a/src/Core/Domain/Employee/Entities/Employee.cs
+++ b/src/Core/Domain/Employee/Entities/Employee.cs
@@ -21,7 +21,7 @@ public class Employee : Person
         bool isActive,
         int id = 0)
     {
-        Cpf = new string(cpf.Where(char.IsDigit).ToArray());
+        Cpf = cpf.SanitizeCpf();
         Name = name;
         Surname = surname;
         Email = email;


### PR DESCRIPTION
This pull request introduces a new helper method to sanitize CPF strings and refactors existing code to use this method. The changes improve code reusability and readability by centralizing CPF sanitization logic.

### CPF sanitization improvements:

* [`src/Core/Domain/Base/Extensions/CpfValidationExtensions.cs`](diffhunk://#diff-b065619144bea6856ac966cfb8faedf1393f32cd64aa70e43925461203c0711aR41-R45): Added a new method `SanitizeCpf` to extract only numeric characters from a CPF string.
* [`src/Core/Domain/Customer/Entities/Customer.cs`](diffhunk://#diff-542e630dcf60b3e9214c1089425531ccaf76ca64d9d8f89b19f1b7cf6a9255acL21-R21): Updated the `Customer` constructor to use the new `SanitizeCpf` method for CPF sanitization.
* [`src/Core/Domain/Employee/Entities/Employee.cs`](diffhunk://#diff-2f174dc8cb207348a02f125084d3c6327a33002aa9d52d311c2f28e592209beeL24-R24): Refactored the `Employee` constructor to replace inline CPF sanitization with the `SanitizeCpf` method.