### PR TITLE
adjust active product logic to throw the exception properly

### DIFF
--- a/src/Core/Application/Products/ProductManager.cs
+++ b/src/Core/Application/Products/ProductManager.cs
@@ -52,14 +52,11 @@ public class ProductManager : IProductManager
     {
         var products = await _productRepository.GetProductsByIds(ids, cancellationToken);
 
-        if (products is null || products.Count == 0)
-            return null;
+        if (products is null || products.Count == 0 || products.Count < ids.Length)
+            throw new InvalidProductException();
 
         if (products.Any(p => !p.IsActive))
             throw new DeactivatedProductException();
-
-        if (products.Count < ids.Length)
-            throw new InvalidProductException();
 
         return products.ConvertAll(p => new ProductDto(p));
     }


### PR DESCRIPTION
This pull request modifies the `ProductManager` class in `src/Core/Application/Products/ProductManager.cs` to improve error handling when fetching products by IDs. The key change ensures that an `InvalidProductException` is thrown earlier in the validation process when the number of fetched products is less than the number of requested IDs.

Error handling improvements:

* [`src/Core/Application/Products/ProductManager.cs`](diffhunk://#diff-8e8721394bc16868c4ea811809059914ff0355e13f1e2eb66137d74886f0df8dL55-L63): Updated the condition to throw `InvalidProductException` earlier if the fetched products are null, empty, or fewer than the requested IDs. This improves clarity and ensures invalid product scenarios are handled consistently.