### PR TITLE
validate Cpf null condition and update JSON options to ignore null

### DIFF
--- a/src/Adapters/Driving/TechChallengeFastFood.API/Program.cs
+++ b/src/Adapters/Driving/TechChallengeFastFood.API/Program.cs
@@ -50,7 +50,11 @@ public class Program
         builder.Services.AddExceptionHandler<CustomExceptionHandler>();
         builder.Configuration.AddEnvironmentVariables();
         builder.Services.AddControllers().AddJsonOptions(options =>
-                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()))
+                {
+                    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+                }
+            )
             .ConfigureApiBehaviorOptions(setupAction =>
             {
                 setupAction.InvalidModelStateResponseFactory = context =>
@@ -103,7 +107,7 @@ public class Program
         builder.Services.AddTransient<IPaymentService, PaymentService>();
         builder.Services.AddTransient<IPaymentProcessorFactory, PaymentProcessorFactory>();
         builder.Services.AddTransient<MercadoPagoPaymentProcessor>();
-        
+
         builder.Services.AddTransient<ICustomerManager, CustomerManager>();
         builder.Services.AddTransient<ICustomerRepository, CustomerRepository>();
 
@@ -117,7 +121,7 @@ public class Program
         });
 
         builder.Services.AddTransient<IPasswordManager, PasswordManager>();
-        
+
         builder.Services.AddSwaggerGen(s =>
         {
             s.SwaggerDoc("v1", new OpenApiInfo
@@ -176,8 +180,8 @@ public class Program
                     ValidIssuer = builder.Configuration["Jwt:Issuer"],
                     ValidAudience = builder.Configuration["Jwt:Audience"],
                     IssuerSigningKey =
-                         new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(
-                             System.Text.Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
+                        new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(
+                            System.Text.Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]))
                 };
             });
 

--- a/src/Core/Domain/Order/Entities/Order.cs
+++ b/src/Core/Domain/Order/Entities/Order.cs
@@ -59,7 +59,7 @@ public class Order : BaseEntity
 
     private void ValidateOrder()
     {
-        if (!Cpf.IsValidCpf())
+        if (Cpf is not null && !Cpf.IsValidCpf())
             throw new InvalidCpfException();
 
         if (OrderItems.Count == 0)


### PR DESCRIPTION
This pull request makes improvements to JSON serialization settings and validation logic in the codebase. The most important changes include adding a condition to ignore null values during JSON serialization and enhancing the CPF validation logic to avoid null reference exceptions.

### JSON Serialization Improvements:
* [`src/Adapters/Driving/TechChallengeFastFood.API/Program.cs`](diffhunk://#diff-9f64b3ccd5fff960da96e05dddae01176dcd840c4ab83ff1d3e899bb503c2d5dL53-R57): Updated JSON serialization options to ignore null values by setting `JsonSerializerOptions.DefaultIgnoreCondition` to `JsonIgnoreCondition.WhenWritingNull`.

### Validation Logic Enhancements:
* [`src/Core/Domain/Order/Entities/Order.cs`](diffhunk://#diff-9b4a26623a7371bdd4b500163412223fa08d138aadabb21d4549f2ac47b42685L62-R62): Improved CPF validation by adding a null check to ensure `Cpf` is not null before calling `IsValidCpf()`. This prevents potential null reference exceptions.…lues