### PR TITLE
feat: initialize Helm chart with deployment, service, and ingress configurations

### DIFF
--- a/infra/helm/techchallengefastfoodapi118fase2/.helmignore
+++ b/infra/helm/techchallengefastfoodapi118fase2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/helm/techchallengefastfoodapi118fase2/Chart.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: techchallengefastfoodapi118fase2
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/NOTES.txt
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "techchallengefastfoodapi118fase2.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "techchallengefastfoodapi118fase2.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "techchallengefastfoodapi118fase2.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "techchallengefastfoodapi118fase2.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/_helpers.tpl
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "techchallengefastfoodapi118fase2.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "techchallengefastfoodapi118fase2.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "techchallengefastfoodapi118fase2.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "techchallengefastfoodapi118fase2.labels" -}}
+helm.sh/chart: {{ include "techchallengefastfoodapi118fase2.chart" . }}
+{{ include "techchallengefastfoodapi118fase2.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "techchallengefastfoodapi118fase2.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "techchallengefastfoodapi118fase2.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "techchallengefastfoodapi118fase2.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "techchallengefastfoodapi118fase2.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/deployment.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "techchallengefastfoodapi118fase2.fullname" . }}
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "techchallengefastfoodapi118fase2.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "techchallengefastfoodapi118fase2.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/hpa.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "techchallengefastfoodapi118fase2.fullname" . }}
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "techchallengefastfoodapi118fase2.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/ingress.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "techchallengefastfoodapi118fase2.fullname" . }}
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "techchallengefastfoodapi118fase2.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/service.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "techchallengefastfoodapi118fase2.fullname" . }}
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "techchallengefastfoodapi118fase2.selectorLabels" . | nindent 4 }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/serviceaccount.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "techchallengefastfoodapi118fase2.serviceAccountName" . }}
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/tests/test-connection.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "techchallengefastfoodapi118fase2.fullname" . }}-test-connection"
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "techchallengefastfoodapi118fase2.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -1,0 +1,123 @@
+# Default values for techchallengefastfoodapi118fase2.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/Dockerfile
+++ b/src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/Dockerfile
@@ -9,14 +9,21 @@ ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
 COPY ["src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/TechChallengeFastFood.CleanArch.Infrastructure.API.csproj", "src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/"]
+COPY ["src/CleanArchitecture/Infrastructure/Database.SqlServer/Database.SqlServer.csproj", "src/CleanArchitecture/Infrastructure/Database.SqlServer/"]
+COPY ["src/CleanArchitecture/Infrastructure/External.Api.MercadoPago/External.Api.MercadoPago.csproj", "src/CleanArchitecture/Infrastructure/External.Api.MercadoPago/"]
+COPY ["src/CleanArchitecture/Infrastructure/Infra.Password", "src/CleanArchitecture/Infrastructure/Infra.Password/"]
+
 COPY ["src/CleanArchitecture/Presentation/Controllers/Controllers.csproj", "src/CleanArchitecture/Presentation/Controllers/"]
-COPY ["src/CleanArchitecture/Application/UseCases/UseCases.csproj", "src/CleanArchitecture/Application/UseCases/"]
-COPY ["src/CleanArchitecture/Common/Common.Dto/Common.Dto.csproj", "src/CleanArchitecture/Common/Common.Dto/"]
-COPY ["src/CleanArchitecture/Common/Common.Interfaces/Common.Interfaces.csproj", "src/CleanArchitecture/Common/Common.Interfaces/"]
-COPY ["src/CleanArchitecture/Domain/Entities/Entities.csproj", "src/CleanArchitecture/Domain/Entities/"]
 COPY ["src/CleanArchitecture/Presentation/Gateway/Gateway.csproj", "src/CleanArchitecture/Presentation/Gateway/"]
 COPY ["src/CleanArchitecture/Presentation/Presenters/Presenters.csproj", "src/CleanArchitecture/Presentation/Presenters/"]
-COPY ["src/CleanArchitecture/Infrastructure/Database.SqlServer/Database.SqlServer.csproj", "src/CleanArchitecture/Infrastructure/Database.SqlServer/"]
+
+COPY ["src/CleanArchitecture/Domain/Entities/Entities.csproj", "src/CleanArchitecture/Domain/Entities/"]
+
+COPY ["src/CleanArchitecture/Common/Common.Dto/Common.Dto.csproj", "src/CleanArchitecture/Common/Common.Dto/"]
+COPY ["src/CleanArchitecture/Common/Common.Interfaces/Common.Interfaces.csproj", "src/CleanArchitecture/Common/Common.Interfaces/"]
+COPY ["src/CleanArchitecture/Common/Common.Enums/Common.Enums.csproj", "src/CleanArchitecture/Common/Common.Enums/"]
+
+COPY ["src/CleanArchitecture/Application/UseCases/UseCases.csproj", "src/CleanArchitecture/Application/UseCases/"]
 
 RUN dotnet restore "src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/TechChallengeFastFood.CleanArch.Infrastructure.API.csproj"
 


### PR DESCRIPTION
This pull request introduces a Helm chart for deploying the `techchallengefastfoodapi118fase2` application to Kubernetes. It includes templates for deployment, service, ingress, autoscaling, and other Kubernetes resources, along with configuration files for chart metadata and default values. Additionally, the Dockerfile for the API infrastructure has been updated to include additional dependencies.

### Helm Chart Implementation

#### Chart Metadata and Configuration:
- Added `Chart.yaml` to define chart metadata, including name, description, type, and versioning.
- Added `values.yaml` to specify default configuration values for replicas, image settings, service, ingress, autoscaling, and other Kubernetes resources.

#### Kubernetes Resources:
- Added `deployment.yaml` for defining the deployment resource, including replica count, pod specifications, and container configurations.
- Added `service.yaml` to define the service resource, specifying the service type and port configuration.
- Added `ingress.yaml` for ingress resource configuration, including rules, TLS settings, and annotations.
- Added `hpa.yaml` for horizontal pod autoscaler configuration to enable autoscaling based on CPU and memory utilization.
- Added `serviceaccount.yaml` for defining a service account resource with optional annotations and automount settings.

#### Utility Templates:
- Added `_helpers.tpl` for reusable template functions, such as generating names, labels, and service account names.
- Added `NOTES.txt` for providing post-installation instructions to users, including commands to access the application.

#### Testing:
- Added `test-connection.yaml` for a test Pod to verify connectivity to the service.

### Dockerfile Updates
- Updated Dockerfile to include additional dependencies for `Database.SqlServer`, `External.Api.MercadoPago`, `Infra.Password`, `Common.Enums`, and other modules. This ensures all necessary components are included for building the application.

### Miscellaneous
- Added `.helmignore` to specify patterns to exclude during chart packaging, such as IDE files and VCS directories.…figurations