### PR TITLE
feat: create initial Helm chart for SQL Server deployment

### DIFF
--- a/infra/helm/devsqlchart/.helmignore
+++ b/infra/helm/devsqlchart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/helm/devsqlchart/Chart.yaml
+++ b/infra/helm/devsqlchart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: devsqlchart
+description: A Helm chart for Kubernetes SQL Server to be used on Tech Challenge
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/infra/helm/devsqlchart/templates/NOTES.txt
+++ b/infra/helm/devsqlchart/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "devsqlchart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "devsqlchart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "devsqlchart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "devsqlchart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/infra/helm/devsqlchart/templates/_helpers.tpl
+++ b/infra/helm/devsqlchart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "devsqlchart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "devsqlchart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "devsqlchart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "devsqlchart.labels" -}}
+helm.sh/chart: {{ include "devsqlchart.chart" . }}
+{{ include "devsqlchart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "devsqlchart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "devsqlchart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "devsqlchart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "devsqlchart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/infra/helm/devsqlchart/templates/deployment.yaml
+++ b/infra/helm/devsqlchart/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+        app: {{ .Values.name }}
+    spec:
+      initContainers:
+        - name: volumepermissions
+          image: busybox
+          command: ["sh", "-c", "chown -R 10001:0 /var/opt/mssql"]
+          volumeMounts:
+            - mountPath: "/var/opt/mssql"
+              name: sqldata-storage
+      volumes:
+        - name: sqldata-storage
+          persistentVolumeClaim:
+            claimName: dbclaim
+      containers:
+        - name: {{ .Values.name }}
+          volumeMounts:
+            - mountPath: "/var/opt/mssql/data"
+              name: sqldata-storage
+          image: mcr.microsoft.com/mssql/server:2019-latest
+          ports:
+            - containerPort: 1433
+          env:
+            - name: ACCEPT_EULA
+              value: "Y"
+            - name: SA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sql-password
+                  key: sa_password
+            - name: MSSQL_PID
+              value: Developer
+            - name: MSSQL_MEMORY_LIMIT_MB
+              value: "1000"

--- a/infra/helm/devsqlchart/templates/persistentvolumeclaim.yaml
+++ b/infra/helm/devsqlchart/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dbclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/infra/helm/devsqlchart/templates/secret.yaml
+++ b/infra/helm/devsqlchart/templates/secret.yaml
@@ -1,0 +1,8 @@
+# TODO: REPLACE WITH TEMPLATE VARIABLES
+
+apiVersion: v1
+data:
+  sa_password: TXNzcWwhUGFzc3cwcmQ=
+kind: Secret
+metadata:
+  name: sql-password

--- a/infra/helm/devsqlchart/templates/service.yaml
+++ b/infra/helm/devsqlchart/templates/service.yaml
@@ -1,0 +1,55 @@
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: sqlserver
+# spec:
+#   ports:
+#     - name: sqlserver
+#       port: 1433
+#       targetPort: 1433
+#   selector:
+#     name: sqlserver
+#   type: LoadBalancer
+
+{{- if .Values.service }}
+{{- $name := .Values.name -}}
+{{- $labels := .Values.service.labels -}}
+{{- $annotations := .Values.service.annotations -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- with $labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ $service.name }}
+spec:
+  type: {{ $service.type }}
+  {{- $service.loadBalancerIP }}
+  loadBalancerIP: {{ $service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  {{- if $service.portAndTargetList }}
+  {{- range $service.portAndTargetList }}
+  - name: "{{ .port }}-{{ .targetPort }}"
+    port: {{ .port }}
+    targetPort: {{ .targetPort }}
+  {{- end }}
+  {{- else }}
+  - name: "{{ $service.port }}-{{ $service.targetPort }}"
+    port: {{ $service.port }}
+    targetPort: {{ $service.targetPort }}
+    {{- if $service.nodePort }}
+    nodePort: {{ $service.nodePort }}
+    {{- end }}
+  {{- end }}
+  selector:
+    name: {{ .Values.name }}
+
+{{- end }}
+{{- end }}

--- a/infra/helm/devsqlchart/templates/serviceaccount.yaml
+++ b/infra/helm/devsqlchart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "devsqlchart.serviceAccountName" . }}
+  labels:
+    {{- include "devsqlchart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/devsqlchart/values.yaml
+++ b/infra/helm/devsqlchart/values.yaml
@@ -1,0 +1,9 @@
+
+name: sqlserver
+
+service:
+  type: 'LoadBalancer'
+  port: 1433
+
+serviceAccount:
+  create: false


### PR DESCRIPTION
This pull request introduces a new Helm chart, `devsqlchart`, designed to deploy a SQL Server instance on Kubernetes. The changes include the addition of essential Helm files, templates, and configurations to define the chart structure, deployment specifications, and supporting resources like persistent volumes and secrets.

### Helm Chart Configuration:

* [`infra/helm/devsqlchart/Chart.yaml`](diffhunk://#diff-0a9516429db2a1ef0b9a884a0b1008c03176e9753cb5a4cb20f379147ce247a6R1-R24): Defined the chart metadata, including `apiVersion`, `name`, `description`, `type`, and versioning details for the chart and the application.
* [`infra/helm/devsqlchart/values.yaml`](diffhunk://#diff-b0d88232ee2ec5735b9fe479177466d49a879b13642d1c9aa855e0b59dc52bc4R1-R9): Added default values for the chart, including the service type (`LoadBalancer`), port (`1433`), and service account configuration.

### Deployment and Resource Templates:

* [`infra/helm/devsqlchart/templates/deployment.yaml`](diffhunk://#diff-7b76d4301fc039941c06b4a0a7def02c3963d5fa3d915718304777265e79b32aR1-R47): Created a Kubernetes Deployment template to deploy SQL Server with an init container for volume permissions, environment variables for configuration, and persistent volume mounts.
* [`infra/helm/devsqlchart/templates/service.yaml`](diffhunk://#diff-ed8f158527d0b7301b34bd685a64203ff15d60c0c8590e49d8b6fcbe3ee3b710R1-R55): Added a Service template to expose the SQL Server, supporting dynamic configurations for ports, annotations, and labels.
* [`infra/helm/devsqlchart/templates/persistentvolumeclaim.yaml`](diffhunk://#diff-c52d23f20f088d1365089c51a8b4ab02c11e2ddd50daf986994a27912c6165c5R1-R10): Defined a PersistentVolumeClaim template to allocate storage for the SQL Server data.
* [`infra/helm/devsqlchart/templates/secret.yaml`](diffhunk://#diff-0e6bdf7993c29406196f31f905ce2e9b08670e4a56f01817a4da2573f113bb27R1-R8): Created a Secret template to securely store the SQL Server administrator password.

### Supporting Files:

* [`infra/helm/devsqlchart/templates/_helpers.tpl`](diffhunk://#diff-2c8b2ebf5494cf012f1c455738b7323d756d90e4cd148119bca6d96372e2c710R1-R62): Added helper functions to generate consistent names, labels, and service account configurations across the chart.
* [`infra/helm/devsqlchart/templates/NOTES.txt`](diffhunk://#diff-f46aef0f9058d95e4633fa5d47c024a7f0794400d2d3c9c465bdeed234c1eef0R1-R22): Included post-deployment instructions for accessing the application based on the service type.
* [`infra/helm/devsqlchart/.helmignore`](diffhunk://#diff-76eed4a19a8816e139733ae4696c4821c9f53599ff1e9a14c5c5b72ad582e8dfR1-R23): Added patterns to ignore unnecessary files during chart packaging, such as IDE-specific files and version control directories.