### PR TITLE
feat: update CI configuration to allow pushes from both develop and main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         file: src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/Dockerfile # Adjust path if necessary
 
     - name: Log in to Azure Container Registry
-      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && github.event_name == 'push'
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
@@ -80,7 +80,7 @@ jobs:
         password: ${{ env.ACR_PASSWORD }}
 
     - name: Build Docker image (Main branch)
-      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && github.event_name == 'push'
       uses: docker/build-push-action@v5
       with:
         context: .
@@ -92,20 +92,20 @@ jobs:
         file: src/CleanArchitecture/Infrastructure/TechChallengeFastFood.CleanArch.Infrastructure.API/Dockerfile # Adjust path if necessary
 
     - name: Set up Helm
-      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'      
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && github.event_name == 'push'
       uses: azure/setup-helm@v3
       with:
         version: '3.12.0'
     
     - name: Package Helm chart
-      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'    
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && github.event_name == 'push'    
       run: |
         VERSION="1.0.${{ github.run_number }}"
         helm package ./infra/helm/${{ env.HELM_CHART_NAME }} --version $VERSION
         echo "HELM_VERSION=$VERSION" >> $GITHUB_ENV
         
     - name: Push Helm chart to ACR
-      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'    
+      if: (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && github.event_name == 'push'
       run: |
         helm registry login ${{ env.REGISTRY }} --username ${{ env.ACR_USERNAME }} --password ${{ env.ACR_PASSWORD }}
         helm push ${{ env.HELM_CHART_NAME }}-${{ env.HELM_VERSION }}.tgz oci://${{ env.REGISTRY }}/helm        


### PR DESCRIPTION
This pull request updates the CI workflow to allow deployments from both the `develop` and `main` branches, instead of only from `develop`. The changes ensure that Docker image builds and Helm chart packaging and publishing steps are triggered for pushes to either branch.

CI/CD workflow updates:

* Expanded branch conditions for Azure Container Registry login and Docker image build steps to include both `develop` and `main` branches in `.github/workflows/ci.yml`.
* Updated branch conditions for Helm setup, chart packaging, and chart push steps to support deployments from both `develop` and `main` branches in `.github/workflows/ci.yml`