### PR TITLE
adjust liveness e readiness

### DIFF
--- a/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
@@ -93,14 +93,19 @@ livenessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 4
 readinessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -96,14 +96,19 @@ livenessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 4
 readinessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:


### PR DESCRIPTION
This pull request updates the Kubernetes health check configuration for the API in both production and development Helm values files. The main goal is to make the liveness and readiness probes less aggressive, which can help prevent premature restarts and allow the application more time to start up and respond.

**Probe configuration updates:**

* Increased `initialDelaySeconds` and `periodSeconds` for the `livenessProbe` in both `values-production.template.yaml` and `values.yaml`, allowing the application more time before health checks begin and between checks. [[1]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L96-R108) [[2]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL99-R111)
* Added `timeoutSeconds`, `successThreshold`, and `failureThreshold` to the `livenessProbe` to fine-tune when the application is considered healthy or unhealthy. [[1]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L96-R108) [[2]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL99-R111)
* Increased `initialDelaySeconds` and added `timeoutSeconds` and `failureThreshold` to the `readinessProbe`, making readiness checks less strict and reducing the chance of marking the app as not ready too soon. [[1]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L96-R108) [[2]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL99-R111)