### PR TITLE
Develop

### DIFF
--- a/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
@@ -93,14 +93,19 @@ livenessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 4
 readinessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -96,14 +96,19 @@ livenessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 4
 readinessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:


### PR DESCRIPTION
This pull request updates the Kubernetes probe configurations in both production and default Helm chart values to improve the reliability of health checks for the API. The main changes involve increasing the delay and period for liveness and readiness probes, as well as adding new thresholds and timeouts to make the probes more robust.

**Probe configuration improvements:**

* Increased `initialDelaySeconds` and `periodSeconds` for `livenessProbe` to allow more startup time and reduce probe frequency in both `values-production.template.yaml` and `values.yaml`. [[1]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L96-R108) [[2]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL99-R111)
* Added `timeoutSeconds`, `successThreshold`, and `failureThreshold` to `livenessProbe` for more precise control over probe behavior. [[1]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L96-R108) [[2]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL99-R111)
* Increased `initialDelaySeconds` and added `timeoutSeconds` and `failureThreshold` to `readinessProbe` to better handle slow startups and transient failures. [[1]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L96-R108) [[2]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL99-R111)