### PR TITLE
Develop

### DIFF
--- a/infra/helm/techchallengefastfoodapi118fase2/templates/NOTES.txt
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/NOTES.txt
@@ -1,8 +1,8 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
+{{- if .Values.externalIngress.enabled }}
+{{- range $host := .Values.externalIngress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.externalIngress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else }}

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/externalIngress.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/externalIngress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.externalIngress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/infra/helm/techchallengefastfoodapi118fase2/templates/internalIngress.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/internalIngress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.internalIngress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "techchallengefastfoodapi118fase2.fullname" . }}-internal
+  labels:
+    {{- include "techchallengefastfoodapi118fase2.labels" . | nindent 4 }}
+  {{- with .Values.internalIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.internalIngress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.internalIngress.tls }}
+  tls:
+    {{- range .Values.internalIngress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: {{ include "techchallengefastfoodapi118fase2.fullname" $ }}
+            port:
+              number: {{ $.Values.service.port }}
+        path: /
+        pathType: Prefix
+{{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
@@ -64,12 +64,12 @@ service:
       portName: http
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-ingress:
+externalIngress:
   enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
-  # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -79,6 +79,17 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+internalIngress:
+  enabled: true
+  className: "nginx-internal-static"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local  
 
 resources:
   limits:

--- a/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values-production.template.yaml
@@ -93,14 +93,19 @@ livenessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 4
 readinessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -96,14 +96,19 @@ livenessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 30
-  periodSeconds: 10
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 30
+  successThreshold: 1
+  failureThreshold: 4
 readinessProbe:
   httpGet:
     path: /healthz  # Update this to match your API's health endpoint
     port: http
-  initialDelaySeconds: 5
+  initialDelaySeconds: 30
   periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -67,7 +67,7 @@ service:
       portName: http
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
-ingress:
+externalIngress:
   enabled: false
   className: ""
   annotations: {}
@@ -82,6 +82,17 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+internalIngress:
+  enabled: true
+  className: "nginx-internal-static"
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local  
 
 resources:
   limits:


### PR DESCRIPTION
This pull request refactors the ingress configuration for the Helm chart to support separate internal and external ingress resources. The main changes include renaming and updating values for external ingress, adding a new internal ingress resource, and updating documentation and templates to reflect these changes.

**Ingress configuration refactor:**

* Renamed `ingress` to `externalIngress` in both `values.yaml` and `values-production.template.yaml`, and updated all references in templates to use the new name. [[1]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddL70-R70) [[2]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439L67-R67) [[3]](diffhunk://#diff-6f091f5c9fc7941d4da6c8da9bd5bc6a1d57800d563dab6995444967edef2998L1-R1) [[4]](diffhunk://#diff-559ca3369772b292e4792b7b1e9e6f8055470a53859a5695519647994742b5c9L2-R5)
* Added a new `internalIngress` configuration block in both `values.yaml` and `values-production.template.yaml`, enabling support for an internal ingress resource with customizable class, annotations, and TLS settings. [[1]](diffhunk://#diff-8875c2914178f7afc27e8f07f9942f55cc12c5769f5866ce3387f0813cafcdddR86-R96) [[2]](diffhunk://#diff-3e14de894939b35cb56279a4f552c50de11458f1767a8838fafa27e2756f3439R83-R93)

**Template updates:**

* Added a new `internalIngress.yaml` template to create an internal ingress resource when enabled, with support for custom annotations, class, and TLS configuration.
* Renamed `ingress.yaml` to `externalIngress.yaml` and updated its logic to use `externalIngress` values instead of the previous `ingress` values.

**Documentation update:**

* Updated `NOTES.txt` to reference `externalIngress` instead of `ingress`, ensuring instructions match the new configuration structure.