### PR TITLE
feat: update internal ingress configuration to use service instances

### DIFF
--- a/infra/helm/techchallengefastfoodapi118fase2/templates/internalIngress.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/internalIngress.yaml
@@ -28,9 +28,9 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "techchallengefastfoodapi118fase2.fullname" $ }}
+            name: {{ (index .Values.service.instances 0).name }}
             port:
-              number: {{ $.Values.service.port }}
+              number: {{ (index .Values.service.instances 0).port }}
         path: /
         pathType: Prefix
 {{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -57,13 +57,12 @@ securityContext: {}
 service:
   # Default port for ingress and test compatibility
   port: 80
-  instances:      
-# Configuration to test the api that runs inside cluster
-    - name: fastfood-api-nodeport
-      type: NodePort
+  instances:
+    # Configuration to test the api that runs inside cluster
+    - name: fastfood-api-clusterip
+      type: ClusterIP
       port: 80
       targetPort: 8080
-      nodePort: 30080
       portName: http
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
This pull request updates the Helm configuration for the Fast Food API service to improve internal service referencing and adjust the default service type for in-cluster deployments. The changes focus on ensuring that the internal ingress correctly references the first service instance and updating the service type from `NodePort` to `ClusterIP` for better compatibility with cluster networking.

Service configuration updates:
* Changed the default service instance in `values.yaml` from `NodePort` to `ClusterIP`, removed the `nodePort` field, and updated the instance name to `fastfood-api-clusterip`. This aligns the configuration with typical in-cluster service exposure patterns.

Ingress template improvements:
* Modified the internal ingress template to reference the first service instance’s name and port from the `instances` list in `values.yaml`, rather than using hardcoded values. This makes the ingress configuration more flexible and consistent with the service definitions.