### PR TITLE
Develop

### DIFF
--- a/infra/helm/techchallengefastfoodapi118fase2/templates/internalIngress.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/templates/internalIngress.yaml
@@ -28,9 +28,9 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ include "techchallengefastfoodapi118fase2.fullname" $ }}
+            name: {{ (index .Values.service.instances 0).name }}
             port:
-              number: {{ $.Values.service.port }}
+              number: {{ (index .Values.service.instances 0).port }}
         path: /
         pathType: Prefix
 {{- end }}

--- a/infra/helm/techchallengefastfoodapi118fase2/values.yaml
+++ b/infra/helm/techchallengefastfoodapi118fase2/values.yaml
@@ -57,13 +57,12 @@ securityContext: {}
 service:
   # Default port for ingress and test compatibility
   port: 80
-  instances:      
-# Configuration to test the api that runs inside cluster
-    - name: fastfood-api-nodeport
-      type: NodePort
+  instances:
+    # Configuration to test the api that runs inside cluster
+    - name: fastfood-api-clusterip
+      type: ClusterIP
       port: 80
       targetPort: 8080
-      nodePort: 30080
       portName: http
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
This pull request updates the Helm chart configuration to change the internal service type from `NodePort` to `ClusterIP` and ensures that the ingress template references the correct service instance details. These changes improve the deployment's compatibility and security by using a more appropriate service type for internal access.

**Service type and configuration changes:**

* Changed the first service instance in `service.instances` from `NodePort` to `ClusterIP` in `values.yaml`, removed the `nodePort` field, and updated the service name to `fastfood-api-clusterip`.

**Ingress template updates:**

* Modified the ingress template to reference the first service instance's name and port dynamically, ensuring it matches the updated service configuration.